### PR TITLE
Update runtime.txt from python-3.7.6 to python-3.9.1

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.9.1


### PR DESCRIPTION
Changed as heroku stack 20 doesn't support python 3.7.6